### PR TITLE
Neue Chat-Befehle für Spieler

### DIFF
--- a/src/nss/module_chat.nss
+++ b/src/nss/module_chat.nss
@@ -1111,6 +1111,8 @@ void main() {
             } else if (sMessage == "/hilfe") {
                 SendMessageToPC(oPc, "/afk\n" +
                                     "/geist\n" +
+                                    "/unstuck\n" +
+                                    "/report\n" +
                                     "/token\n" +
                                     "/familiar\n" +
                                     "/companion\n" +


### PR DESCRIPTION
Spieler und Spielleiter haben nun Zugriff auf die Befehle:
- /unstuck (versetzt den Charakter ein paar Schritte in Blickrichtung) 
- /report <Fehlerbeschreibung> (erfasst einen Fehlerbericht im Discord mit Position und Namen des Charakters)